### PR TITLE
feat!: add block streaming interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,12 @@ export interface Block {
   bytes: Uint8Array
 }
 
-export interface Blockstore extends BlockGetter, BlockStreamer {}
+export interface BlockStat {
+  /** Total size in bytes of the block. */
+  size: number
+}
+
+export interface Blockstore extends BlockGetter, BlockStreamer, BlockInspecter {}
 
 export interface BlockGetter {
   /** Retrieve a block. */
@@ -33,6 +38,11 @@ export interface BlockGetter {
 export interface BlockStreamer {
   /** Stream bytes from a block. */
   stream: (cid: UnknownLink, options?: AbortOptions & RangeOptions) => Promise<ReadableStream<Uint8Array>|undefined>
+}
+
+export interface BlockInspecter {
+  /** Retrieve information about a block. */
+  stat: (cid: UnknownLink, options?: AbortOptions) => Promise<BlockStat|undefined>
 }
 
 export interface Network {
@@ -132,7 +142,7 @@ export interface EntityBytesOptions {
 
 export interface RangeOptions {
   /** Extracts a specific byte range from the resource. */
-  range: Range
+  range?: Range
 }
 
 /**
@@ -165,6 +175,8 @@ export interface IDagula extends BlockService, DagService, UnixfsService {}
 export interface BlockService {
   /** Get a single block. */
   getBlock (cid: UnknownLink|string, options?: AbortOptions): Promise<Block>
+  /** Retrieve information about a block. */
+  statBlock (cid: UnknownLink|string, options?: AbortOptions): Promise<BlockStat>
   /** Stream bytes from a single block. */
   streamBlock (cid: UnknownLink|string, options?: AbortOptions & RangeOptions): Promise<ReadableStream<Uint8Array>>
 }
@@ -191,6 +203,8 @@ export declare class Dagula implements BlockService, DagService, UnixfsService {
   getPath (cidPath: string, options?: AbortOptions & DagScopeOptions & EntityBytesOptions & BlockOrderOptions): AsyncIterableIterator<Block>
   /** Get a single block. */
   getBlock (cid: UnknownLink|string, options?: AbortOptions): Promise<Block>
+  /** Retrieve information about a block. */
+  statBlock (cid: UnknownLink|string, options?: AbortOptions): Promise<BlockStat>
   /** Stream bytes from a single block. */
   streamBlock (cid: UnknownLink|string, options?: AbortOptions & RangeOptions): Promise<ReadableStream<Uint8Array>>
   /** Get UnixFS files and directories. */

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,8 @@ import type { Stream } from '@libp2p/interface-connection'
 import type { StreamHandler } from '@libp2p/interface-registrar'
 import type { PeerId } from '@libp2p/interface-peer-id'
 
+export type { AbortOptions }
+
 export interface BlockDecoders {
   [code: number]: BlockDecoder<any, any>
 }
@@ -21,8 +23,16 @@ export interface Block {
   bytes: Uint8Array
 }
 
-export interface Blockstore {
-  get: (cid: UnknownLink, options?: { signal?: AbortSignal }) => Promise<Block | undefined>
+export interface Blockstore extends BlockGetter, BlockStreamer {}
+
+export interface BlockGetter {
+  /** Retrieve a block. */
+  get: (cid: UnknownLink, options?: AbortOptions) => Promise<Block|undefined>
+}
+
+export interface BlockStreamer {
+  /** Stream bytes from a block. */
+  stream: (cid: UnknownLink, options?: AbortOptions & RangeOptions) => Promise<ReadableStream<Uint8Array>|undefined>
 }
 
 export interface Network {
@@ -63,27 +73,66 @@ export interface DagScopeOptions {
 }
 
 /**
- * Specifies a range of bytes.
- * - `*` can be substituted for end-of-file
- *     - `{ from: 0, to: '*' }` is the entire file.
- * - Negative numbers can be used for referring to bytes from the end of a file
- *     - `{ from: -1024, to: '*' }` is the last 1024 bytes of a file.
- * - It is also permissible to ask for the range of 500 bytes from the
- * beginning of the file to 1000 bytes from the end: `{ from: 499, to: -1000 }`
+ * An absolute byte range to extract - always an array of two values
+ * corresponding to the first and last bytes (both inclusive). e.g.
+ * 
+ * ```
+ * [100, 200]
+ * ```
  */
-export interface ByteRange {
-  /** Byte-offset of the first byte in a range (inclusive) */
-  from: number
-  /** Byte-offset of the last byte in the range (inclusive) */
-  to: number|'*'
-}
+export type AbsoluteRange = [first: number, last: number]
+
+/**
+ * An suffix byte range - always an array of one value corresponding to the
+ * first byte to start extraction from (inclusive). e.g.
+ * 
+ * ```
+ * [900]
+ * ```
+ * 
+ * If it is unknown how large a resource is, the last `n` bytes
+ * can be requested by specifying a negative value:
+ * 
+ * ```
+ * [-100]
+ * ```
+ */
+export type SuffixRange = [first: number]
+
+/**
+ * Byte range to extract - an array of one or two values corresponding to the
+ * first and last bytes (both inclusive). e.g.
+ * 
+ * ```
+ * [100, 200]
+ * ```
+ * 
+ * Omitting the second value requests all remaining bytes of the resource. e.g.
+ * 
+ * ```
+ * [900]
+ * ```
+ * 
+ * Alternatively, if it's unknown how large a resource is, the last `n` bytes
+ * can be requested by specifying a negative value:
+ * 
+ * ```
+ * [-100]
+ * ```
+ */
+export type Range = AbsoluteRange | SuffixRange
 
 export interface EntityBytesOptions {
   /**
    * A specific byte range from the entity. Setting entity bytes implies DAG
    * scope: entity.
    */
-  entityBytes?: ByteRange
+  entityBytes?: Range
+}
+
+export interface RangeOptions {
+  /** Extracts a specific byte range from the resource. */
+  range: Range
 }
 
 /**
@@ -110,49 +159,42 @@ export interface BlockOrderOptions {
   order?: BlockOrder
 }
 
-export interface IDagula {
-  /**
-   * Get a complete DAG by root CID.
-   */
-  get (cid: UnknownLink|string, options?: AbortOptions & BlockOrderOptions): AsyncIterableIterator<Block>
-  /**
-   * Get a DAG for a cid+path.
-   */
-  getPath (cidPath: string, options?: AbortOptions & DagScopeOptions & EntityBytesOptions & BlockOrderOptions): AsyncIterableIterator<Block>
-  /**
-   * Get a single block.
-   */
+/** @deprecated Use `BlockService`, `DagService` and `UnixfsService` interface instead. */
+export interface IDagula extends BlockService, DagService, UnixfsService {}
+
+export interface BlockService {
+  /** Get a single block. */
   getBlock (cid: UnknownLink|string, options?: AbortOptions): Promise<Block>
-  /**
-   * Get UnixFS files and directories.
-   */
+  /** Stream bytes from a single block. */
+  streamBlock (cid: UnknownLink|string, options?: AbortOptions & RangeOptions): Promise<ReadableStream<Uint8Array>>
+}
+
+export interface DagService {
+  /** Get a complete DAG by root CID. */
+  get (cid: UnknownLink|string, options?: AbortOptions & BlockOrderOptions): AsyncIterableIterator<Block>
+  /** Get a DAG for a cid+path. */
+  getPath (cidPath: string, options?: AbortOptions & DagScopeOptions & EntityBytesOptions & BlockOrderOptions): AsyncIterableIterator<Block>
+}
+
+export interface UnixfsService {
+  /** Get UnixFS files and directories. */
   getUnixfs (path: UnknownLink|string, options?: AbortOptions): Promise<UnixFSEntry>
-  /**
-   * Emit nodes for all path segements and get UnixFS files and directories.
-   */
+  /** Emit nodes for all path segements and get UnixFS files and directories. */
   walkUnixfsPath (path: UnknownLink|string, options?: AbortOptions): AsyncIterableIterator<UnixFSEntry>
 }
 
-export declare class Dagula implements IDagula {
+export declare class Dagula implements BlockService, DagService, UnixfsService {
   constructor (blockstore: Blockstore, options?: { decoders?: BlockDecoders, hashers?: MultihashHashers })
-  /**
-   * Get a complete DAG by root CID.
-   */
+  /** Get a complete DAG by root CID. */
   get (cid: UnknownLink|string, options?: AbortOptions & BlockOrderOptions): AsyncIterableIterator<Block>
-  /**
-   * Get a DAG for a cid+path.
-   */
+  /** Get a DAG for a cid+path. */
   getPath (cidPath: string, options?: AbortOptions & DagScopeOptions & EntityBytesOptions & BlockOrderOptions): AsyncIterableIterator<Block>
-  /**
-   * Get a single block.
-   */
+  /** Get a single block. */
   getBlock (cid: UnknownLink|string, options?: AbortOptions): Promise<Block>
-  /**
-   * Get UnixFS files and directories.
-   */
+  /** Stream bytes from a single block. */
+  streamBlock (cid: UnknownLink|string, options?: AbortOptions & RangeOptions): Promise<ReadableStream<Uint8Array>>
+  /** Get UnixFS files and directories. */
   getUnixfs (path: UnknownLink|string, options?: AbortOptions): Promise<UnixFSEntry>
-  /**
-   * Emit nodes for all path segements and get UnixFS files and directories.
-   */
+  /** Emit nodes for all path segements and get UnixFS files and directories. */
   walkUnixfsPath (path: UnknownLink|string, options?: AbortOptions): AsyncIterableIterator<UnixFSEntry>
 }

--- a/index.js
+++ b/index.js
@@ -10,14 +10,15 @@ import { identity } from 'multiformats/hashes/identity'
 import { depthFirst, breadthFirst } from './traversal.js'
 
 /**
+ * @typedef {import('./index').DagService} DagService
  * @typedef {{ unixfs?: UnixFS }} LinkFilterContext
  * @typedef {([name, cid]: [string, import('multiformats').UnknownLink], context: LinkFilterContext) => boolean} LinkFilter
- * @typedef {[from: number, to: number]} Range
- * @typedef {{ cid: import('multiformats').UnknownLink, range?: Range }} GraphSelector
+ * @typedef {{ cid: import('multiformats').UnknownLink, range?: import('./index').AbsoluteRange }} GraphSelector
  */
 
 const log = debug('dagula')
 
+/** @implements {DagService} */
 export class Dagula {
   /** @type {import('./index').Blockstore} */
   #blockstore
@@ -44,7 +45,7 @@ export class Dagula {
    * @param {object} [options]
    * @param {AbortSignal} [options.signal]
    * @param {import('./index').BlockOrder} [options.order]
-   * @param {import('./index').ByteRange} [options.entityBytes]
+   * @param {import('./index').Range} [options.entityBytes]
    * @param {LinkFilter} [options.filter]
    */
   async * get (cid, options = {}) {
@@ -137,7 +138,7 @@ export class Dagula {
    *    'entity': Mimic gateway semantics: Return All blocks for a multi-block file or just enough blocks to enumerate a dir/map but not the dir contents.
    *     Where path points to a single block file, all three selectors would return the same thing.
    *     where path points to a sharded hamt: 'file' returns the blocks of the hamt so the dir can be listed. 'block' returns the root block of the hamt.
-   * @param {import('./index').ByteRange} [options.entityBytes]
+   * @param {import('./index').Range} [options.entityBytes]
    */
   async * getPath (cidPath, options = {}) {
     const dagScope = options.dagScope ?? (options.entityBytes ? 'entity' : 'all')
@@ -188,20 +189,20 @@ export class Dagula {
     if (!base) throw new Error('walkPath did not yield an entry')
 
     if (dagScope === 'all' || (dagScope === 'entity' && base.type !== 'directory')) {
-      /** @type {Range|undefined} */
+      /** @type {import('./index').AbsoluteRange|undefined} */
       let range
       if (entityBytes) {
         const size = Number(base.size)
         // resolve entity bytes to actual byte offsets
         range = [
-          entityBytes.from < 0
-            ? size - 1 + entityBytes.from
-            : entityBytes.from,
-          entityBytes.to === '*'
+          entityBytes[0] < 0
+            ? size - 1 + entityBytes[0]
+            : entityBytes[0],
+          entityBytes[1] == null
             ? size - 1
-            : entityBytes.to < 0
-              ? size - 1 + entityBytes.to
-              : entityBytes.to
+            : entityBytes[1] < 0
+              ? size - 1 + entityBytes[1]
+              : entityBytes[1]
         ]
       }
       const selectors = getUnixfsEntryLinkSelectors(base, this.#decoders, range)
@@ -236,6 +237,28 @@ export class Dagula {
       throw Object.assign(new Error(`peer does not have: ${cid}`), { code: 'ERR_DONT_HAVE' })
     }
     return block
+  }
+
+  /**
+   * @param {import('multiformats').UnknownLink|string} cid
+   * @param {import('./index').AbortOptions & import('./index').RangeOptions} [options]
+   */
+  async streamBlock (cid, options) {
+    cid = typeof cid === 'string' ? CID.parse(cid) : cid
+    log('streaming block %s', cid)
+    if (cid.code === identity.code) {
+      return new ReadableStream({
+        pull (controller) {
+          controller.enqueue(cid.multihash.digest)
+          controller.close()
+        }
+      })
+    }
+    const readable = await this.#blockstore.stream(cid, options)
+    if (!readable) {
+      throw Object.assign(new Error(`peer does not have: ${cid}`), { code: 'ERR_DONT_HAVE' })
+    }
+    return readable
   }
 
   /**
@@ -347,7 +370,7 @@ function toRanges (blockSizes) {
   const ranges = []
   let offset = 0
   for (const size of blockSizes) {
-    /** @type {Range} */
+    /** @type {import('./index').AbsoluteRange} */
     const absRange = [offset, offset + size - 1]
     ranges.push(absRange)
     offset += size
@@ -367,9 +390,9 @@ function toRanges (blockSizes) {
  * toRelativeRange([100,200], [300,400]): undefined
  * ```
  *
- * @param {Range} a
- * @param {Range} b
- * @returns {Range|undefined}
+ * @param {import('./index').AbsoluteRange} a
+ * @param {import('./index').AbsoluteRange} b
+ * @returns {import('./index').AbsoluteRange|undefined}
  */
 const toRelativeRange = (a, b) => {
   // starts in range
@@ -396,7 +419,7 @@ const toRelativeRange = (a, b) => {
  *
  * @param {import('ipfs-unixfs-exporter').UnixFSEntry} entry
  * @param {import('./index').BlockDecoders} decoders
- * @param {Range} [range]
+ * @param {import('./index').AbsoluteRange} [range]
  * @returns {GraphSelector[]}
  */
 function getUnixfsEntryLinkSelectors (entry, decoders, range) {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,9 @@ import { identity } from 'multiformats/hashes/identity'
 import { depthFirst, breadthFirst } from './traversal.js'
 
 /**
+ * @typedef {import('./index').BlockService} BlockService
  * @typedef {import('./index').DagService} DagService
+ * @typedef {import('./index').UnixfsService} UnixfsService
  * @typedef {{ unixfs?: UnixFS }} LinkFilterContext
  * @typedef {([name, cid]: [string, import('multiformats').UnknownLink], context: LinkFilterContext) => boolean} LinkFilter
  * @typedef {{ cid: import('multiformats').UnknownLink, range?: import('./index').AbsoluteRange }} GraphSelector
@@ -18,7 +20,11 @@ import { depthFirst, breadthFirst } from './traversal.js'
 
 const log = debug('dagula')
 
-/** @implements {DagService} */
+/**
+ * @implements {BlockService}
+ * @implements {DagService}
+ * @implements {UnixfsService}
+ */
 export class Dagula {
   /** @type {import('./index').Blockstore} */
   #blockstore

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "p-defer": "^4.0.0",
         "protobufjs": "^7.0.0",
         "sade": "^1.8.1",
-        "streaming-iterables": "^7.0.4",
+        "streaming-iterables": "^8.0.1",
         "timeout-abort-controller": "^3.0.0",
         "varint": "^6.0.0"
       },
@@ -6658,15 +6658,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/miniswap/node_modules/streaming-iterables": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-8.0.1.tgz",
-      "integrity": "sha512-yfQdmUB1b+rGLZkD/r6YisT/eNOjZxBAckXKlzYNmRJnwSzHaiScykD8gsQceFcShtK09qAbLhOqvzIpnBPoDQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/mortice": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.1.tgz",
@@ -7976,11 +7967,11 @@
       "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
     },
     "node_modules/streaming-iterables": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-7.1.0.tgz",
-      "integrity": "sha512-t2KmiLVhqafTRqGefD98s5XAMskfkfprr/BTzPIZz0kWB23iyR7XUkY03yjUf4aZpAuuV2/2SUOVri3LgKuOKw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-8.0.1.tgz",
+      "integrity": "sha512-yfQdmUB1b+rGLZkD/r6YisT/eNOjZxBAckXKlzYNmRJnwSzHaiScykD8gsQceFcShtK09qAbLhOqvzIpnBPoDQ==",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/streamsearch": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "p-defer": "^4.0.0",
     "protobufjs": "^7.0.0",
     "sade": "^1.8.1",
-    "streaming-iterables": "^7.0.4",
+    "streaming-iterables": "^8.0.1",
     "timeout-abort-controller": "^3.0.0",
     "varint": "^6.0.0"
   },

--- a/test/getPath.test.js
+++ b/test/getPath.test.js
@@ -11,6 +11,7 @@ import { sha256 } from 'multiformats/hashes/sha2'
 import { identity } from 'multiformats/hashes/identity'
 import { CID } from 'multiformats/cid'
 import * as Block from 'multiformats/block'
+import { collect } from 'streaming-iterables'
 import { Dagula } from '../index.js'
 import { getLibp2p, fromNetwork } from '../p2p.js'
 import { startBitswapPeer } from './_libp2p.js'
@@ -569,12 +570,3 @@ test('should yield intermediate blocks when last path component does not exist',
   t.is(blocks.length, 1)
   t.is(blocks[0].cid.toString(), fileLink.cid.toString())
 })
-
-/** @param {AsyncIterable} source */
-async function collect (source) {
-  const blocks = []
-  for await (const block of source) {
-    blocks.push(block)
-  }
-  return blocks
-}

--- a/test/statBlock.test.js
+++ b/test/statBlock.test.js
@@ -1,0 +1,20 @@
+import test from 'ava'
+import { fromString } from 'multiformats/bytes'
+import * as raw from 'multiformats/codecs/raw'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { CID } from 'multiformats/cid'
+import { getLibp2p, fromNetwork } from '../p2p.js'
+import { startBitswapPeer } from './_libp2p.js'
+
+test('should stat a block', async t => {
+  const bytes = fromString(`TEST DATA ${Date.now()}`)
+  const hash = await sha256.digest(bytes)
+  const cid = CID.create(1, raw.code, hash)
+  const peer = await startBitswapPeer([{ cid, bytes }])
+
+  const libp2p = await getLibp2p()
+  const dagula = await fromNetwork(libp2p, { peer: peer.libp2p.getMultiaddrs()[0] })
+  const { size } = await dagula.statBlock(cid)
+
+  t.is(size, bytes.length)
+})

--- a/test/streamBlock.test.js
+++ b/test/streamBlock.test.js
@@ -1,0 +1,41 @@
+import test from 'ava'
+import { fromString, toString } from 'multiformats/bytes'
+import * as raw from 'multiformats/codecs/raw'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { CID } from 'multiformats/cid'
+import { collect } from 'streaming-iterables'
+import { getLibp2p, fromNetwork } from '../p2p.js'
+import { startBitswapPeer } from './_libp2p.js'
+
+test('should stream a block', async t => {
+  const bytes = fromString(`TEST DATA ${Date.now()}`)
+  const hash = await sha256.digest(bytes)
+  const cid = CID.create(1, raw.code, hash)
+  const peer = await startBitswapPeer([{ cid, bytes }])
+
+  const libp2p = await getLibp2p()
+  const dagula = await fromNetwork(libp2p, { peer: peer.libp2p.getMultiaddrs()[0] })
+  const readable = await dagula.streamBlock(cid)
+  t.assert(readable)
+
+  // @ts-expect-error one day all things will implement
+  const chunks = await collect(readable)
+  t.is(await new Blob(chunks).text(), toString(bytes))
+})
+
+test('should stream a byte range from a block', async t => {
+  const bytes = fromString(`TEST DATA ${Date.now()}`)
+  const range = /** @type {import('../index').AbsoluteRange} */ ([5, 8])
+  const hash = await sha256.digest(bytes)
+  const cid = CID.create(1, raw.code, hash)
+  const peer = await startBitswapPeer([{ cid, bytes }])
+
+  const libp2p = await getLibp2p()
+  const dagula = await fromNetwork(libp2p, { peer: peer.libp2p.getMultiaddrs()[0] })
+  const readable = await dagula.streamBlock(cid, { range })
+  t.assert(readable)
+
+  // @ts-expect-error one day all things will implement
+  const chunks = await collect(readable)
+  t.is(await new Blob(chunks).text(), toString(bytes.slice(range[0], range[1] + 1)))
+})

--- a/test/testmark.test.js
+++ b/test/testmark.test.js
@@ -20,7 +20,7 @@ const parseQuery = query => {
   const entityBytes = url.searchParams.get('entity-bytes')
   if (entityBytes && entityBytes !== 'null') {
     const [from, to] = entityBytes.split(':')
-    options.entityBytes = { from: parseInt(from), to: to === '*' ? to : parseInt(to) }
+    options.entityBytes = to === '*' ? [parseInt(from)] : [parseInt(from), parseInt(to)]
   }
   const cidPath = url.pathname.replace('/ipfs/', '').split('/').map(decodeURIComponent).join('/')
   return { cidPath, options }


### PR DESCRIPTION
This PR adds a `streamBlock(cid, [options])` method to Dagula that returns a `ReadableStream` of block bytes. You can optionally pass a byte range to extract a subset of bytes.

Also `statBlock(cid, [options])` that retrieves block info i.e. total size in bytes.

The idea is to allow dagula to serve byte ranges from big blocks without having to load the whole thing into memory.

BREAKING CHANGE: The `Blockstore` interface now includes a `stream` method that returns a `ReadableStream` and a `stat` method that returns info (byte size).

The format for the `entityBytes` option of `getPath` has changed. It is now an array of 1 or 2 numbers. See `Range` type for more details.

refs https://github.com/web3-storage/freeway/pull/100#discussion_r1591594799